### PR TITLE
Add `es` folder to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "files": [
     "lib",
     "src",
-    "dist"
+    "dist",
+    "es"
   ],
   "bugs": {
     "url": "https://github.com/reactjs/reselect/issues"


### PR DESCRIPTION
There is no `es` folder in npm package. `eslint-plaugin-import` throw errors in my projects
